### PR TITLE
Wait for the element scope

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,7 @@
 language: ruby
 rvm:
-  - 2.3.0
+  - 2.7.1
+services:
+  - xvfb
 addons:
   chrome: stable
-before_script:
-  - sudo apt-get install chromium-chromedriver
-  - sudo ln -s /usr/lib/chromium-browser/chromedriver /usr/bin/chromedriver
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - sleep 3 # give xvfb some time to start

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'http://rubygems.org'
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.unshift File.expand_path('lib', __dir__)
 
 require 'bundler'

--- a/lib/watirsome.rb
+++ b/lib/watirsome.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Watirsome
   class << self
     #

--- a/lib/watirsome/accessors.rb
+++ b/lib/watirsome/accessors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Watirsome
   module Accessors
     SKIP_CUSTOM_SELECTORS = %i[visible].freeze

--- a/lib/watirsome/errors.rb
+++ b/lib/watirsome/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Watirsome
   CannotPluralizeError = Class.new(StandardError)
 end

--- a/lib/watirsome/initializers.rb
+++ b/lib/watirsome/initializers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Watirsome
   #
   # Initializes page class.

--- a/lib/watirsome/regions.rb
+++ b/lib/watirsome/regions.rb
@@ -81,7 +81,7 @@ module Watirsome
                   end
 
           if each
-            elements = (scope.exists? ? scope.elements(each) : [])
+            elements = scope.elements(each)
 
             if collection_class_name && namespace.const_defined?(collection_class_name)
               region_collection_class = namespace.const_get(collection_class_name)

--- a/lib/watirsome/regions.rb
+++ b/lib/watirsome/regions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Watirsome
   module Regions
     #

--- a/lib/watirsome/version.rb
+++ b/lib/watirsome/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Watirsome
-  VERSION = '0.3.0'.freeze
+  VERSION = '0.3.0'
 end

--- a/spec/elements_spec.rb
+++ b/spec/elements_spec.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 module ElementsSpec
   class GreetingPage
     include Watirsome
 
-    URL = "file:///#{File.expand_path('support/greeter.html')}".freeze
+    URL = "file:///#{File.expand_path('support/greeter.html')}"
 
     text_field :name, id: 'name'
     button :set, id: 'set_name'

--- a/spec/inheritance_spec.rb
+++ b/spec/inheritance_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module InheritanceSpec
   class ToDoListItemBase
     include Watirsome
@@ -20,7 +22,7 @@ module InheritanceSpec
   class ToDoListPageBase
     include Watirsome
 
-    URL = "file:///#{File.expand_path('support/todo_lists.html')}".freeze
+    URL = "file:///#{File.expand_path('support/todo_lists.html')}"
     has_one :todo_list, region_class: ToDoList
   end
 

--- a/spec/initializers_spec.rb
+++ b/spec/initializers_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module InitializersSpec
   class InitializedRegion
     include Watirsome
@@ -14,7 +16,7 @@ module InitializersSpec
 
     attr_reader :ready
 
-    URL = "file:///#{File.expand_path('support/greeter.html')}".freeze
+    URL = "file:///#{File.expand_path('support/greeter.html')}"
 
     has_one :region, region_class: InitializedRegion
 

--- a/spec/legacy/click_accessors_spec.rb
+++ b/spec/legacy/click_accessors_spec.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module ClickAccessorsSpec
-  URL = "file:///#{File.expand_path('support/doctest.html')}".freeze
+  URL = "file:///#{File.expand_path('support/doctest.html')}"
 
   class Page
     include Watirsome

--- a/spec/legacy/collection_region_from_itself_spec.rb
+++ b/spec/legacy/collection_region_from_itself_spec.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module CollectionRegionFromItselfSpec
-  URL = "file:///#{File.expand_path('support/doctest.html')}".freeze
+  URL = "file:///#{File.expand_path('support/doctest.html')}"
 
   class UserRegion
     include Watirsome

--- a/spec/legacy/collection_region_using_block_spec.rb
+++ b/spec/legacy/collection_region_using_block_spec.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module CollectionRegionUsingBlockSpec
-  URL = "file:///#{File.expand_path('support/doctest.html')}".freeze
+  URL = "file:///#{File.expand_path('support/doctest.html')}"
 
   class Page
     include Watirsome

--- a/spec/legacy/collection_region_using_class_spec.rb
+++ b/spec/legacy/collection_region_using_class_spec.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module CollectionRegionUsingClassSpec
-  URL = "file:///#{File.expand_path('support/doctest.html')}".freeze
+  URL = "file:///#{File.expand_path('support/doctest.html')}"
 
   class UserRegion
     include Watirsome

--- a/spec/legacy/collection_scope_with_watir_element_spec.rb
+++ b/spec/legacy/collection_scope_with_watir_element_spec.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module CollectionScopeWithWatirElementSpec
-  URL = "file:///#{File.expand_path('support/doctest.html')}".freeze
+  URL = "file:///#{File.expand_path('support/doctest.html')}"
 
   class UserRegion
     include Watirsome

--- a/spec/legacy/collection_scope_with_watir_selector_spec.rb
+++ b/spec/legacy/collection_scope_with_watir_selector_spec.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module CollectionScopeWithWatirSelectorSpec
-  URL = "file:///#{File.expand_path('support/doctest.html')}".freeze
+  URL = "file:///#{File.expand_path('support/doctest.html')}"
 
   class UserRegion
     include Watirsome

--- a/spec/legacy/custom_collection_region_class_spec.rb
+++ b/spec/legacy/custom_collection_region_class_spec.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module CustomCollectionRegionClassSpec
-  URL = "file:///#{File.expand_path('support/doctest.html')}".freeze
+  URL = "file:///#{File.expand_path('support/doctest.html')}"
 
   class UserRegion
     include Watirsome

--- a/spec/legacy/custom_locators_spec.rb
+++ b/spec/legacy/custom_locators_spec.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module CustomLocatorsSpec
-  URL = "file:///#{File.expand_path('support/doctest.html')}".freeze
+  URL = "file:///#{File.expand_path('support/doctest.html')}"
 
   class Page
     include Watirsome

--- a/spec/legacy/element_accessors_spec.rb
+++ b/spec/legacy/element_accessors_spec.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module ElementAccessorsSpec
-  URL = "file:///#{File.expand_path('support/doctest.html')}".freeze
+  URL = "file:///#{File.expand_path('support/doctest.html')}"
 
   class Page
     include Watirsome

--- a/spec/legacy/page_initializer_spec.rb
+++ b/spec/legacy/page_initializer_spec.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module PageInitializerSpec
-  URL = "file:///#{File.expand_path('support/doctest.html')}".freeze
+  URL = "file:///#{File.expand_path('support/doctest.html')}"
 
   class Page
     include Watirsome

--- a/spec/legacy/read_accessors_spec.rb
+++ b/spec/legacy/read_accessors_spec.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module ReadAccessorsSpec
-  URL = "file:///#{File.expand_path('support/doctest.html')}".freeze
+  URL = "file:///#{File.expand_path('support/doctest.html')}"
 
   class Page
     include Watirsome

--- a/spec/legacy/region_initializer_new_api_spec.rb
+++ b/spec/legacy/region_initializer_new_api_spec.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module RegionInitializerNewApiSpec
-  URL = "file:///#{File.expand_path('support/doctest.html')}".freeze
+  URL = "file:///#{File.expand_path('support/doctest.html')}"
 
   class ProfileRegion
     include Watirsome

--- a/spec/legacy/region_initializer_old_api_spec.rb
+++ b/spec/legacy/region_initializer_old_api_spec.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module RegionInitializerOldApiSpec
-  URL = "file:///#{File.expand_path('support/doctest.html')}".freeze
+  URL = "file:///#{File.expand_path('support/doctest.html')}"
 
   module HeaderRegion
     def initialize_region

--- a/spec/legacy/set_accessors_spec.rb
+++ b/spec/legacy/set_accessors_spec.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module SetAccessorsSpec
-  URL = "file:///#{File.expand_path('support/doctest.html')}".freeze
+  URL = "file:///#{File.expand_path('support/doctest.html')}"
 
   class Page
     include Watirsome

--- a/spec/legacy/single_region_using_block_spec.rb
+++ b/spec/legacy/single_region_using_block_spec.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module SingleRegionUsingBlock
-  URL = "file:///#{File.expand_path('support/doctest.html')}".freeze
+  URL = "file:///#{File.expand_path('support/doctest.html')}"
 
   class Page
     include Watirsome

--- a/spec/legacy/single_region_using_class_spec.rb
+++ b/spec/legacy/single_region_using_class_spec.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module SingleRegionUsingClassSpec
-  URL = "file:///#{File.expand_path('support/doctest.html')}".freeze
+  URL = "file:///#{File.expand_path('support/doctest.html')}"
 
   class ProfileRegion
     include Watirsome

--- a/spec/legacy/utils_spec.rb
+++ b/spec/legacy/utils_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Watirsome do
   specify '.clickable?' do
     expect(Watirsome.clickable?(:button)).to eq true

--- a/spec/regions/has_many_spec.rb
+++ b/spec/regions/has_many_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module HasManySpec
   class ToDoListItem
     include Watirsome
@@ -34,7 +36,7 @@ module HasManySpec
   class ToDoListPage
     include Watirsome
 
-    URL = "file:///#{File.expand_path('support/todo_lists.html')}".freeze
+    URL = "file:///#{File.expand_path('support/todo_lists.html')}"
 
     has_many :todo_lists, region_class: ToDoList, each: { role: 'todo_list' }
     has_many :todo_list2s, each: { role: 'todo_list' }

--- a/spec/regions/has_many_spec.rb
+++ b/spec/regions/has_many_spec.rb
@@ -59,9 +59,9 @@ module HasManySpec
       ToDoListPage.new(WatirHelper.browser).tap do |page|
         page.browser.goto page.class::URL
 
-        expect(page.todo_lists.last.class).to eq ToDoList
-        expect(page.todo_lists.last.title).to eq 'Groceries'
-        expect(page.todo_lists.count).to eq 3
+        expect(page.todo_lists[2].class).to eq ToDoList
+        expect(page.todo_lists[2].title).to eq 'Groceries'
+        expect(page.todo_lists.count).to eq 4
       end
     end
 
@@ -69,9 +69,9 @@ module HasManySpec
       ToDoListPage.new(WatirHelper.browser).tap do |page|
         page.browser.goto page.class::URL
 
-        expect(page.todo_list_inlines.count).to eq 3
-        expect(page.todo_list_inlines.last.title).to eq 'Groceries'
-        expect(page.todo_list_inlines.last.items.first.name).to eq 'Bread'
+        expect(page.todo_list_inlines.count).to eq 4
+        expect(page.todo_list_inlines[2].title).to eq 'Groceries'
+        expect(page.todo_list_inlines[2].items.first.name).to eq 'Bread'
       end
     end
 
@@ -80,9 +80,9 @@ module HasManySpec
         page.browser.goto page.class::URL
 
         expect(page.todo_list2s).to be_a TodoList2sRegion
-        expect(page.todo_list2s.region_collection.last).to be_a TodoList2Region
-        expect(page.todo_list2s.region_collection.last.title).to eq 'Groceries'
-        expect(page.todo_list2s.region_collection.count).to eq 3
+        expect(page.todo_list2s.region_collection[2]).to be_a TodoList2Region
+        expect(page.todo_list2s.region_collection[2].title).to eq 'Groceries'
+        expect(page.todo_list2s.region_collection.count).to eq 4
       end
     end
 
@@ -100,9 +100,9 @@ module HasManySpec
       ToDoListPage.new(WatirHelper.browser).tap do |page|
         page.browser.goto page.class::URL
 
-        expect(page.todo_lists.last.items.first).to be_a ToDoListItem
-        expect(page.todo_lists.last.items.first.name).to eq 'Bread'
-        expect(page.todo_lists.last.items.count).to eq 3
+        expect(page.todo_lists[2].items.first).to be_a ToDoListItem
+        expect(page.todo_lists[2].items.first.name).to eq 'Bread'
+        expect(page.todo_lists[2].items.count).to eq 3
       end
     end
 

--- a/spec/regions/has_one_spec.rb
+++ b/spec/regions/has_one_spec.rb
@@ -34,6 +34,12 @@ module HasOneSpec
 
     has_one :home_todo_list, region_class: ToDoList, within: { id: 'todos_home' }
 
+    has_one :movies_todo_list, within: { id: 'todos_movies', visible: true }do
+      has_many :items, each: { tag_name: :li } do
+        span :name, role: 'name'
+      end
+    end
+
     def home_todo_list
       super.title
     end
@@ -82,6 +88,13 @@ module HasOneSpec
       ToDoListPage.new(WatirHelper.browser).tap do |page|
         page.browser.goto page.class::URL
         expect(page.home_todo_list).to eq 'Home'
+      end
+    end
+
+    it 'waits for the element scope' do
+      ToDoListPage.new(WatirHelper.browser).tap do |page|
+        page.browser.goto page.class::URL
+        expect(page.movies_todo_list.items.first.name).to eq 'The Shawshank Redemption'
       end
     end
   end

--- a/spec/regions/has_one_spec.rb
+++ b/spec/regions/has_one_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module HasOneSpec
   class ToDoListItem
     include Watirsome
@@ -22,7 +24,7 @@ module HasOneSpec
   class ToDoListPage
     include Watirsome
 
-    URL = "file:///#{File.expand_path('support/todo_lists.html')}".freeze
+    URL = "file:///#{File.expand_path('support/todo_lists.html')}"
     has_one :todo_list, region_class: ToDoList, within: { id: 'todos_work' }
     has_one :todo_list_default, within: -> { browser.element(id: 'todos_work') }
     has_one :todo_list_inline, within: -> { region_element.element(id: 'todos_work') } do
@@ -34,7 +36,7 @@ module HasOneSpec
 
     has_one :home_todo_list, region_class: ToDoList, within: { id: 'todos_home' }
 
-    has_one :movies_todo_list, within: { id: 'todos_movies', visible: true }do
+    has_one :movies_todo_list, within: { id: 'todos_movies', visible: true } do
       has_many :items, each: { tag_name: :li } do
         span :name, role: 'name'
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'watir'
 require 'pry'
 require_relative '../lib/watirsome'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'watir'
 require 'pry'
 require_relative '../lib/watirsome'
+require 'webdrivers'
 
 class WatirHelper
   class << self

--- a/support/todo_lists.html
+++ b/support/todo_lists.html
@@ -53,6 +53,10 @@
     li.parentNode.removeChild(li)
   }
 
+  function showMovies() {
+    document.getElementById("todos_movies").style.visibility = "visible";
+  }
+  setTimeout("showMovies()", 500);
   </script>
 </head>
 <body>
@@ -83,6 +87,16 @@
       <li><span role="name">Bread</span><a role="rm" onclick="rmTodoItem(this)">[rm]</a></li>
       <li><span role="name">Tomatos</span><a role="rm" onclick="rmTodoItem(this)">[rm]</a></li>
       <li><span role="name">Green pesto</span><a role="rm" onclick="rmTodoItem(this)">[rm]</a></li>
+    </ul>
+  </div>
+
+  <div id="todos_movies" role="todo_list" style="visibility: hidden">
+    <div role="title">Movies</div>
+    <input role="new_item" /><button role="add" onclick="addItem(this)">Add</button>
+    <ul>
+      <li><span role="name">The Shawshank Redemption</span></li>
+      <li><span role="name">The Godfather</span></li>
+      <li><span role="name">The Dark Knight</span></li>
     </ul>
   </div>
 

--- a/watirsome.gemspec
+++ b/watirsome.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rubocop'
+  s.add_development_dependency 'webdrivers'
 end

--- a/watirsome.gemspec
+++ b/watirsome.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.push File.expand_path('lib', __dir__)
 require 'watirsome/version'
 


### PR DESCRIPTION
Currently, Watirsome doesn't wait for an element scope.

For example, in a statement `page.movies_todo_list.items.size` if `movies_todo_list` doesn't yet exist on the page, then Watirsome won't wait for it.

Watir handles waiting for element scope (see e.g. https://github.com/watir/watir/issues/759) so Watirsome should too.

Most of the changes in PR are CI fixes and are split into commits.