### PR TITLE
Wait for region element to appear

### DIFF
--- a/lib/watirsome/regions.rb
+++ b/lib/watirsome/regions.rb
@@ -125,11 +125,13 @@ module Watirsome
       finder_method_name = region_name.to_s.sub(/s\z/, '')
       include(Module.new do
         define_method(finder_method_name) do |**opts|
-          __send__(region_name).find do |entity|
-            opts.all? do |key, value|
-              entity.__send__(key) == value
+          Watir::Wait.until(message: "No #{finder_method_name} matching: #{opts}.") do
+            __send__(region_name).find do |entity|
+              opts.all? do |key, value|
+                entity.__send__(key) == value
+              end
             end
-          end || raise("No #{finder_method_name} matching: #{opts}.")
+          end
         end
       end)
     end

--- a/spec/legacy/collection_region_using_class_spec.rb
+++ b/spec/legacy/collection_region_using_class_spec.rb
@@ -27,7 +27,7 @@ module CollectionRegionUsingClassSpec
         # You can search for particular regions in collection.
         expect(page.user(name: 'John Smith 1').name).to eq 'John Smith 1'
         expect(page.user(name: 'John Smith 2').name).to eq 'John Smith 2'
-        expect { page.user(name: 'John Smith 3') }.to raise_error(RuntimeError, /No user matching:/)
+        expect { page.user(name: 'John Smith 3') }.to raise_error(Watir::Wait::TimeoutError, /No user matching:/)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,8 @@ class WatirHelper
   end
 end
 
+Watir.default_timeout = 3
+
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true


### PR DESCRIPTION
Wait automatically in cases like:
```
has_many :items do
  td :name, class: 'name'
  def choose
    click_something
  end
end
page.item(name: 'Andrei').choose
```
This is useful in cases when the list is dynamic, and the element to be chosen is not available immediately.

Watir waits automatically in a case like below so I think Watirsome should wait too:
```
browser.elements(...).first.element(...).click
```

Waiting in watir happens only when `click` is invoked but I'm not sure how to implement that with watirsome but I think it's OK to do it when locating element. At least, an error about element not found was raised before when locating element.

I think watirsome should wait too.